### PR TITLE
synthesizing: Pattern_from_Targets ExprStmt lists

### DIFF
--- a/semgrep-core/src/synthesizing/Range_to_AST.mli
+++ b/semgrep-core/src/synthesizing/Range_to_AST.mli
@@ -5,3 +5,17 @@
 val expr_at_range : Range.t -> AST_generic.program -> AST_generic.expr option
 
 val any_at_range : Range.t -> AST_generic.program -> AST_generic.any option
+
+(* Repeatedly calls any_at_range to consume as much of the target input as possible.
+ * If a call at any_at_range does not consume the entire token range, then
+ * any_at_range is called again with a new target range starting where the last call
+ * left off.
+
+ * For example, range provided by the user is (0, 29). First call to any_at_range
+ * returns found (0, 17). The found match is added to the list and then
+ * any_at_range is called again with (18, 29). If another match is found
+ * then it is appended to the list.
+
+ * Empty list is returned if no matches are found.
+ *)
+val many_at_range : Range.t -> AST_generic.program -> AST_generic.any list

--- a/semgrep-core/src/synthesizing/Synthesizer.ml
+++ b/semgrep-core/src/synthesizing/Synthesizer.ml
@@ -7,23 +7,33 @@ let range_to_ast file lang s =
     Parse_target.parse_and_resolve_name_use_pfff_or_treesitter lang file
   in
   if errors <> [] then failwith (spf "problem parsing %s" file);
-  let a_opt = Range_to_AST.any_at_range r ast in
+  let a_opt = Range_to_AST.many_at_range r ast in
   Naming_AST.resolve lang ast;
   Constant_propagation.propagate_basic lang ast;
   Constant_propagation.propagate_dataflow ast;
   match a_opt with
-  | Some a -> a
-  | None -> failwith (spf "could not find an expr at range %s in %s" s file)
+  | [] -> failwith (spf "could not find an expr at range %s in %s" s file)
+  | _ -> a_opt
 
 let synthesize_patterns config s file =
   let lang = Lang.langs_of_filename file |> List.hd in
-  let a = range_to_ast file lang s in
+  (* range_to_ast returns a list of subtrees to be used by Pattern_from_Targets.
+   * Pattern_from_Code only handles a single expression, so we take
+   * the first element here. This matches previous behavior when range_to_ast
+   * returned a single subtree.
+   *)
+  let a = List.hd (range_to_ast file lang s) in
   let patterns = Pattern_from_Code.from_any config a in
   List.map
     (fun (k, v) -> (k, Pretty_print_generic.pattern_to_string lang v))
     patterns
 
-let generate_pattern_choices config s =
+let print_target lang target =
+  let print_pattern_line p = Pretty_print_generic.pattern_to_string lang p in
+  let target_str = List.map print_pattern_line target |> String.concat "\n" in
+  "target: [\n" ^ target_str ^ "\n]\n"
+
+let parse_range_args s =
   let rec read_input xs =
     match xs with
     | [] -> raise WrongNumberOfArguments
@@ -32,13 +42,17 @@ let generate_pattern_choices config s =
         let ranges, file = read_input xs in
         (x :: ranges, file)
   in
-  let ranges, file = read_input s in
+  read_input s
+
+let parse_targets (args : string list) : Pattern.t list list * Lang.t =
+  let ranges, file = parse_range_args args in
   let lang = Lang.langs_of_filename file |> List.hd in
   let targets = List.map (range_to_ast file lang) ranges in
-  List.map
-    (fun target ->
-      "target: " ^ Pretty_print_generic.pattern_to_string lang target)
-    targets
+  (targets, lang)
+
+let generate_pattern_choices config s =
+  let targets, lang = parse_targets s in
+  List.map (print_target lang) targets
   @ List.map
       (Pretty_print_generic.pattern_to_string lang)
       (Pattern_from_Targets.generate_patterns config targets lang)


### PR DESCRIPTION
Add support for targets that are ExprStmt lists in Pattern_from_Targets.

For example, two separate targets might be

```
x = req.query.foo;
exec(x);
```

and

```
y = req.query.foo;
exec(y);
```

yielding the pattern

```
$X = req.query.foo;
exec($X);
```

Limitations:
- Targets must be of equal length. Cannot yet generate ellipsis for
statements to equalize length of targets.
- No additional support for statements other than ExprStmt.



PR checklist:
- [ ] changelog is up to date

